### PR TITLE
Changed copies to references

### DIFF
--- a/examples/MEEvent.cpp
+++ b/examples/MEEvent.cpp
@@ -2,7 +2,7 @@
 
 #include "MEEvent.h"
 
-void MEEvent::SetVectors(const ROOT::Math::PtEtaPhiEVector ep, const ROOT::Math::PtEtaPhiEVector mum, const ROOT::Math::PtEtaPhiEVector b, const ROOT::Math::PtEtaPhiEVector bbar, const ROOT::Math::PtEtaPhiEVector met){
+void MEEvent::SetVectors(const ROOT::Math::PtEtaPhiEVector &ep, const ROOT::Math::PtEtaPhiEVector &mum, const ROOT::Math::PtEtaPhiEVector &b, const ROOT::Math::PtEtaPhiEVector &bbar, const ROOT::Math::PtEtaPhiEVector &met){
   p3 = ep;
   p5 = mum;
   p4 = b;

--- a/examples/MEEvent.h
+++ b/examples/MEEvent.h
@@ -6,7 +6,7 @@
 class MEEvent{
   public:
 
-  void SetVectors(const ROOT::Math::PtEtaPhiEVector ep, const ROOT::Math::PtEtaPhiEVector mum, const ROOT::Math::PtEtaPhiEVector b, const ROOT::Math::PtEtaPhiEVector bbar, const ROOT::Math::PtEtaPhiEVector met);
+  void SetVectors(const ROOT::Math::PtEtaPhiEVector &ep, const ROOT::Math::PtEtaPhiEVector &mum, const ROOT::Math::PtEtaPhiEVector &b, const ROOT::Math::PtEtaPhiEVector &bbar, const ROOT::Math::PtEtaPhiEVector &met);
 
   inline const ROOT::Math::PtEtaPhiEVector& GetP3() const { return p3; }
   inline const ROOT::Math::PtEtaPhiEVector& GetP4() const { return p4; }

--- a/examples/MEWeight.cpp
+++ b/examples/MEWeight.cpp
@@ -36,7 +36,7 @@ MEWeight::MEWeight(const std::string paramCardPath, const std::string pdfName, c
   myTF = new TransferFunction(fileTF);
 }
 
-double MEWeight::ComputePdf(const int pid, const double x, const double q2){
+double MEWeight::ComputePdf(const int &pid, const double &x, const double &q2){
   // return f(pid,x,q2)
   if(x <= 0 || x >= 1 || q2 <= 0){
     cout << "WARNING: PDF x or Q^2 value out of bounds!" << endl;
@@ -50,7 +50,7 @@ MEEvent* MEWeight::GetEvent(){
   return myEvent;
 }
 
-void MEWeight::SetEvent(const ROOT::Math::PtEtaPhiEVector ep, const ROOT::Math::PtEtaPhiEVector mum, const ROOT::Math::PtEtaPhiEVector b, const ROOT::Math::PtEtaPhiEVector bbar, const ROOT::Math::PtEtaPhiEVector met){
+void MEWeight::SetEvent(const ROOT::Math::PtEtaPhiEVector &ep, const ROOT::Math::PtEtaPhiEVector &mum, const ROOT::Math::PtEtaPhiEVector &b, const ROOT::Math::PtEtaPhiEVector &bbar, const ROOT::Math::PtEtaPhiEVector &met){
   myEvent->SetVectors(ep, mum, b, bbar, met);
 }
 

--- a/examples/MEWeight.h
+++ b/examples/MEWeight.h
@@ -21,13 +21,13 @@ class MEWeight{
   public:
 
   double Integrand(const double* Xarg, const double *weight);
-  double ComputePdf(const int pid, const double x, const double q2);
+  double ComputePdf(const int &pid, const double &x, const double &q2);
   inline void setProcessMomenta(vector<double*> &p){ process.setMomenta(p); }
   inline void computeMatrixElements(){ process.sigmaKin(); }
   inline const double* const getMatrixElements() const { return process.getMatrixElements(); }
   double ComputeWeight(double &error);
   MEEvent* GetEvent();
-  void SetEvent(const ROOT::Math::PtEtaPhiEVector ep, const ROOT::Math::PtEtaPhiEVector mum, const ROOT::Math::PtEtaPhiEVector b, const ROOT::Math::PtEtaPhiEVector bbar, const ROOT::Math::PtEtaPhiEVector met);
+  void SetEvent(const ROOT::Math::PtEtaPhiEVector &ep, const ROOT::Math::PtEtaPhiEVector &mum, const ROOT::Math::PtEtaPhiEVector &b, const ROOT::Math::PtEtaPhiEVector &bbar, const ROOT::Math::PtEtaPhiEVector &met);
   void AddTF(const std::string particleName, const std::string histName);
 
   MEWeight(const std::string paramCardPath, const std::string pdfName, const std::string fileTF);

--- a/examples/binnedTF.h
+++ b/examples/binnedTF.h
@@ -12,10 +12,10 @@ class BinnedTF{
 
   BinnedTF(const std::string particleName, const std::string histName, TFile* file);
   ~BinnedTF();
-  inline double Evaluate(const double Erec, const double Egen) const;
-  inline double GetDeltaRange(const double Erec) const;
-  inline double GetDeltaMin(const double Erec) const;
-  inline double GetDeltaMax(const double Erec) const;
+  inline double Evaluate(const double &Erec, const double &Egen) const;
+  inline double GetDeltaRange(const double &Erec) const;
+  inline double GetDeltaMin(const double &Erec) const;
+  inline double GetDeltaMax(const double &Erec) const;
 
   private:
 
@@ -26,7 +26,7 @@ class BinnedTF{
   const TH2D* _TF;
 };
 
-inline double BinnedTF::Evaluate(const double Erec, const double Egen) const {
+inline double BinnedTF::Evaluate(const double &Erec, const double &Egen) const {
   //std::cout << "Evaluating TF for particle " << _particleName << ": Erec = " << Erec << ", Egen = " << Egen << std::endl;
   
   double delta = Erec - Egen;
@@ -43,15 +43,15 @@ inline double BinnedTF::Evaluate(const double Erec, const double Egen) const {
   return _TF->GetBinContent(bin);
 }
 
-inline double BinnedTF::GetDeltaRange(const double Erec) const {
+inline double BinnedTF::GetDeltaRange(const double &Erec) const {
   return GetDeltaMax(Erec) - GetDeltaMin(Erec);
 }
 
-inline double BinnedTF::GetDeltaMin(const double Erec) const {
+inline double BinnedTF::GetDeltaMin(const double &Erec) const {
   return std::max(_deltaMin, Erec - _EgenMax);
 }
 
-inline double BinnedTF::GetDeltaMax(const double Erec) const {
+inline double BinnedTF::GetDeltaMax(const double &Erec) const {
   return std::min(_deltaMax, Erec - _EgenMin);
 }
 

--- a/examples/jacobianD.cpp
+++ b/examples/jacobianD.cpp
@@ -10,8 +10,8 @@
 
 using namespace std;
 
-int ComputeTransformD(const double s13, const double s134, const double s25, const double s256,
-                      const ROOT::Math::PxPyPzEVector p3, const ROOT::Math::PxPyPzEVector p4, const ROOT::Math::PxPyPzEVector p5, const ROOT::Math::PxPyPzEVector p6, const ROOT::Math::PxPyPzEVector Met,
+int ComputeTransformD(const double &s13, const double &s134, const double &s25, const double &s256,
+                      const ROOT::Math::PxPyPzEVector &p3, const ROOT::Math::PxPyPzEVector &p4, const ROOT::Math::PxPyPzEVector &p5, const ROOT::Math::PxPyPzEVector &p6, const ROOT::Math::PxPyPzEVector &Met,
                       std::vector<ROOT::Math::PxPyPzEVector> &p1, std::vector<ROOT::Math::PxPyPzEVector> &p2){
   // pT = transverse total momentum of the visible particles
   ROOT::Math::PxPyPzEVector pT = p3 + p4 + p5 + p6;
@@ -128,7 +128,7 @@ int ComputeTransformD(const double s13, const double s134, const double s25, con
   return p1.size();
 }
 
-double computeJacobianD(const std::vector<ROOT::Math::PxPyPzEVector> p, const double sqrt_s){
+double computeJacobianD(const std::vector<ROOT::Math::PxPyPzEVector> &p, const double &sqrt_s){
   
   const double E1  = p.at(0).E();
   const double p1x = p.at(0).Px();

--- a/examples/jacobianD.h
+++ b/examples/jacobianD.h
@@ -6,10 +6,10 @@
 
 #define INV_JAC_MIN 1e3 // Just as in MW
 
-int ComputeTransformD(const double s13, const double s134, const double s25, const double s256,
-                      const ROOT::Math::PxPyPzEVector p3, const ROOT::Math::PxPyPzEVector p4, const ROOT::Math::PxPyPzEVector p5, const ROOT::Math::PxPyPzEVector p6, const ROOT::Math::PxPyPzEVector Met,
+int ComputeTransformD(const double &s13, const double &s134, const double &s25, const double &s256,
+                      const ROOT::Math::PxPyPzEVector &p3, const ROOT::Math::PxPyPzEVector &p4, const ROOT::Math::PxPyPzEVector &p5, const ROOT::Math::PxPyPzEVector &p6, const ROOT::Math::PxPyPzEVector &Met,
                       std::vector<ROOT::Math::PxPyPzEVector> &p1, std::vector<ROOT::Math::PxPyPzEVector> &p2);
 
-double computeJacobianD(const std::vector<ROOT::Math::PxPyPzEVector> p, const double sqrt_s);
+double computeJacobianD(const std::vector<ROOT::Math::PxPyPzEVector> &p, const double &sqrt_s);
 
 #endif

--- a/examples/transferFunction.h
+++ b/examples/transferFunction.h
@@ -18,10 +18,10 @@ class TransferFunction{
 
   void DefineComponent(const std::string particleName, const std::string histName);
 
-  inline double Evaluate(const std::string particleName, const double Erec, const double Egen);
-  inline double GetDeltaRange(const std::string particleName, const double Erec);
-  inline double GetDeltaMin(const std::string particleName, const double Erec);
-  inline double GetDeltaMax(const std::string particleName, const double Erec);
+  inline double Evaluate(const std::string &particleName, const double &Erec, const double &Egen);
+  inline double GetDeltaRange(const std::string &particleName, const double &Erec);
+  inline double GetDeltaMin(const std::string &particleName, const double &Erec);
+  inline double GetDeltaMax(const std::string &particleName, const double &Erec);
 
   private:
 
@@ -30,7 +30,7 @@ class TransferFunction{
   std::map< std::string, BinnedTF* > _TF;
 };
 
-inline double TransferFunction::Evaluate(const std::string particleName, const double Erec, const double Egen){
+inline double TransferFunction::Evaluate(const std::string &particleName, const double &Erec, const double &Egen){
   // We might want to avoid to check this every time, since it might slow things down too much
   /*if( _TF.find(particleName) == _TF.end() ){
     std::cerr << "Error: TF component for " << particleName << " is not defined!" << std::endl;
@@ -40,7 +40,7 @@ inline double TransferFunction::Evaluate(const std::string particleName, const d
   return _TF[particleName]->Evaluate(Erec, Egen);
 }
 
-inline double TransferFunction::GetDeltaRange(const std::string particleName, const double Erec){
+inline double TransferFunction::GetDeltaRange(const std::string &particleName, const double &Erec){
   // We might want to avoid to check this every time, since it might slow things down too much
   /*if( _TF.find(particleName) == _TF.end() ){
     std::cerr << "Error: TF component for " << particleName << " is not defined!" << std::endl;
@@ -50,7 +50,7 @@ inline double TransferFunction::GetDeltaRange(const std::string particleName, co
   return _TF[particleName]->GetDeltaRange(Erec);
 }
 
-inline double TransferFunction::GetDeltaMin(const std::string particleName, const double Erec){
+inline double TransferFunction::GetDeltaMin(const std::string &particleName, const double &Erec){
   // We might want to avoid to check this every time, since it might slow things down too much
   /*if( _TF.find(particleName) == _TF.end() ){
     std::cerr << "Error: TF component for " << particleName << " is not defined!" << std::endl;
@@ -60,7 +60,7 @@ inline double TransferFunction::GetDeltaMin(const std::string particleName, cons
   return _TF[particleName]->GetDeltaMin(Erec);
 }
 
-inline double TransferFunction::GetDeltaMax(const std::string particleName, const double Erec){
+inline double TransferFunction::GetDeltaMax(const std::string &particleName, const double &Erec){
   // We might want to avoid to check this every time, since it might slow things down too much
   /*if( _TF.find(particleName) == _TF.end() ){
     std::cerr << "Error: TF component for " << particleName << " is not defined!" << std::endl;


### PR DESCRIPTION
Passing complex variables (LorentzVectors, std::vectors, std::strings, ...) by const reference is more efficient than by using copy constructors.
